### PR TITLE
Made the call to init() in DFRobotDFPlayerMini::begin() optional.

### DIFF
--- a/DFRobotDFPlayerMini.cpp
+++ b/DFRobotDFPlayerMini.cpp
@@ -88,7 +88,7 @@ bool DFRobotDFPlayerMini::waitAvailable(){
   return _handleType != TimeOut;
 }
 
-bool DFRobotDFPlayerMini::begin(Stream &stream, bool isACK){
+bool DFRobotDFPlayerMini::begin(Stream &stream, bool isACK, bool doReset){
   if (isACK) {
     enableACK();
   }
@@ -97,11 +97,18 @@ bool DFRobotDFPlayerMini::begin(Stream &stream, bool isACK){
   }
   
   _serial = &stream;
-  _timeOutDuration += 3000;
-  reset();
-  waitAvailable();
-  _timeOutDuration -= 3000;
-  delay(200);
+
+  if (doReset) {
+    _timeOutDuration += 3000;
+    reset();
+    waitAvailable();
+    _timeOutDuration -= 3000;
+    delay(200);
+  } else {
+    // assume same state as with reset(): online
+    _handleType = DFPlayerCardOnline;
+  }
+
   return (readType() == DFPlayerCardOnline) || !isACK;
 }
 

--- a/DFRobotDFPlayerMini.h
+++ b/DFRobotDFPlayerMini.h
@@ -105,7 +105,7 @@ class DFRobotDFPlayerMini {
 
   uint8_t readCommand();
   
-  bool begin(Stream& stream, bool isACK = true);
+  bool begin(Stream& stream, bool isACK = true, bool doReset = true);
   
   bool waitAvailable();
   


### PR DESCRIPTION
calling init() after the module is initially powered on is not necessary
and leads a) to an additional startup latency and b) (more annoying) to a loud
"plop" sound on the speaker output of the DFPlayerMini module.

By adding an optional parameter doReset to the begin() method, the user can now
decide, if the reset should be peformed.  Default is true, which is same
behaviour as now (i.e. perform reset()).