### PR TITLE
added support for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+python:
+    - "2.7"
+env:
+    - BOARD=uno
+    - BOARD=leonardo
+    - BOARD=esp01
+
+install:
+    - python -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio/master/scripts/get-platformio.py)"
+
+script:
+    - cd examples/FullFunction
+    - platformio ci -l ../.. FullFunction.ino --board=$BOARD
+    - cd ../GetStarted
+    - platformio ci -l ../.. getStarted.ino --board=$BOARD
+


### PR DESCRIPTION
I added a .travis-ci.yml file so that the examples and the libraries get compiled and checked automatically on each commit, which greatly improves quality. To use it, you must enable travis-ci integration in github. 

See https://docs.travis-ci.com/user/for-beginners