### PR TITLE
set default value of timeOutDuration to 5000

### DIFF
--- a/DFRobotDFPlayerMini.h
+++ b/DFRobotDFPlayerMini.h
@@ -69,7 +69,7 @@ class DFRobotDFPlayerMini {
   Stream* _serial;
   
   unsigned long _timeOutTimer;
-  unsigned long _timeOutDuration = 500;
+  unsigned long _timeOutDuration = 5000;
   
   uint8_t _received[DFPLAYER_RECEIVED_LENGTH];
   uint8_t _sending[DFPLAYER_SEND_LENGTH] = {0x7E, 0xFF, 06, 00, 01, 00, 00, 00, 00, 0xEF};


### PR DESCRIPTION
DFRobotDFPlayerMini takes about 3-5 seconds to reset. 

v1.0.3 change the waitAvailable function code from
```cpp
bool DFRobotDFPlayerMini::waitAvailable(){
  _isSending = true;
  while (!available()){
    delay(0);
  }
  return _handleType != TimeOut;
}
```
to
```cpp
bool DFRobotDFPlayerMini::waitAvailable(unsigned long duration){
  unsigned long timer = millis();
  if (!duration) {
    duration = _timeOutDuration;
  }
  while (!available()){
    if (millis() - timer > duration) {
      return false;
    }
    delay(0);
  }
  return true;
}
```
It will cause ```bool DFRobotDFPlayerMini::begin``` always failed, then make the examples Getstarted.ino/Fullfunction.ino not work.
Although user can use setTimeOut to set new value, but set a appropriate default value still be necessary.